### PR TITLE
docs: 替换演示视频链接为 GitHub CDN 实现 inline 播放

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Grix is a full-duplex communication platform that brings AI Agents directly into
 
 Watch the 90-second product demo to see Grix in action — AI auto-reply, voice call takeover, and more.
 
-[![Product Overview Demo](assets/grix-product-hunt-demo-voiceover-thumb.jpg)](https://github.com/askie/grix/releases/download/demo-videos/grix-product-hunt-demo-voiceover.mp4)
+<video src="https://github.com/user-attachments/assets/8885112a-8df0-482d-a915-ae0c1cee05a4" controls width="100%"></video>
 
 ### Phone Debug Demo
 
 See how Grix works on mobile — debugging agent replies, switching conversations, and managing chats on the go.
 
-[![Phone Debug Demo](assets/grix-work-debug-phone-thumb.jpg)](https://github.com/askie/grix/releases/download/demo-videos/grix-work-debug-phone.mp4)
+<video src="https://github.com/user-attachments/assets/525e1861-c848-4b12-b25f-3ea548e652ea" controls width="100%"></video>
 
 ## Core Features
 


### PR DESCRIPTION
将两个演示视频的链接从 release asset 切换为 GitHub user-attachments CDN（`<video>` 标签），实现在 README 中 inline 播放，无需点击跳转。

视频来源：https://github.com/askie/grix/issues/1