### PR TITLE
fix(android): route the install permission prompt through the dialog helpers

### DIFF
--- a/frontend/lib/data/providers/app_update_service.dart
+++ b/frontend/lib/data/providers/app_update_service.dart
@@ -796,33 +796,18 @@ class _UpdateDialogState extends State<_UpdateDialog>
     if (!mounted) return;
     setState(() => _stage = _UpdateStage.awaitingPermission);
 
-    final go = await showDialog<bool>(
+    // 走统一的确认框组件族（app_dialog_style），主题、按钮样式和桌面端
+    // Esc/Enter 快捷键都跟着组件族走。正文与厂商提示之间空一行分段——
+    // showAppConfirmDialog 只接受纯文本 message，不支持自定义 content。
+    final go = await showAppConfirmDialog(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text('update_install_permission_title'.tr),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('update_install_permission_body'.tr),
-            const SizedBox(height: 12),
-            Text(_installHintText, style: Theme.of(ctx).textTheme.bodySmall),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text('update_later'.tr),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text('update_go_settings'.tr),
-          ),
-        ],
-      ),
+      title: 'update_install_permission_title'.tr,
+      message: '${'update_install_permission_body'.tr}\n\n$_installHintText',
+      cancelText: 'update_later'.tr,
+      confirmText: 'update_go_settings'.tr,
     );
 
-    if (go != true) {
+    if (!go) {
       // 用户在权限说明这一步放弃：这正是线上安卓装不上的主因，必须能在统计里
       // 看到有多少人卡在这里，而不是只看到「下载成功」。
       unawaited(


### PR DESCRIPTION
安卓 3.2.7+3000 的发布被前端门禁拦下：`test/shared/dialog_usage_guard_test.dart` 报

```
lib/data/providers/app_update_service.dart:799: final go = await showDialog<bool>(
```

项目规范要求 `lib/` 里的确认/信息/输入类弹窗一律走 `lib/shared/widgets/app_dialog_style.dart` 组件族，不得裸用 `showDialog`。同 commit 的 CI Frontend 也是同因红的。

## 改法

`_promptInstallPermission` 里的裸 `showDialog<bool>` 换成 `showAppConfirmDialog`：

- 它本身就返回 `bool`，调用点的语义（true=去设置，false/关闭=放弃）完全不变，下游 `if (!go)` 的 `permission_blocked` 上报路径照旧。
- 两个按钮通过 `cancelText: 'update_later'` / `confirmText: 'update_go_settings'` 保留原文案。
- 主题、按钮样式、桌面端 Esc/Enter 快捷键都跟着组件族走，比原来手写的 AlertDialog 更一致。
- `showAppConfirmDialog` 只接受纯文本 `message`、不支持自定义 content，所以厂商提示从「单独一行 bodySmall」改成正文后空一行的第二段。信息一个字没少，只是不再单独降级排版——为此没有退到 `showAppContentDialog`，因为这里本来就是标准两按钮确认框，用确认框是更贴规范的选择。

净减 15 行。

## 验证

- `flutter test`（**全量**，与 release-public test job 跑的是同一套）：`+2806 ~3: All tests passed!`，exit 0。
- `flutter test test/shared/dialog_usage_guard_test.dart` 单独跑：`+1: All tests passed!`。
- `flutter analyze --no-fatal-infos lib/data/providers/app_update_service.dart`：No issues found。
- 改动仅 1 个文件，`git status` 无其他杂项。
